### PR TITLE
[RREEF-10] Results messages should carry id of original task message.

### DIFF
--- a/lang/cs/Org.Apache.REEF.DistributedR/Network/MessageService.cs
+++ b/lang/cs/Org.Apache.REEF.DistributedR/Network/MessageService.cs
@@ -72,7 +72,7 @@ namespace Org.Apache.REEF.DistributedR.Network
                 }
                 catch (Exception e)
                 {
-                    Logr.Log(Level.Info, "Connect attempt failed." + e.ToString());
+                    Logr.Log(Level.Info, "Connect attempt failed." + e.Message);
                     Thread.Sleep(250);
                 }
             }

--- a/lang/cs/Org.Apache.REEF.DistributedR/Network/Serializer.cs
+++ b/lang/cs/Org.Apache.REEF.DistributedR/Network/Serializer.cs
@@ -154,7 +154,7 @@ namespace Org.Apache.REEF.DistributedR.Network
             }
             catch (Exception e)
             {
-                Logr.Log(Level.Error, "Failure writing message: " + e.ToString());
+                Logr.Log(Level.Error, "Failure writing message: " + e.Message);
                 throw e;
             }
         }
@@ -186,7 +186,7 @@ namespace Org.Apache.REEF.DistributedR.Network
             }
             catch (Exception e)
             {
-                Logr.Log(Level.Error, "Failure reading message: " + e.ToString());
+                Logr.Log(Level.Error, "Failure reading message: " + e.Message);
                 throw e;
             }
         }

--- a/lang/cs/Org.Apache.REEF.DistributedR/Network/ShutdownMsg.cs
+++ b/lang/cs/Org.Apache.REEF.DistributedR/Network/ShutdownMsg.cs
@@ -21,27 +21,23 @@ using System.Runtime.Serialization;
 
 namespace Org.Apache.REEF.DistributedR.Network
 {
-    [DataContract(Name = "RResultsMsg")]
-    [Guid("A50B138D-AE52-4D09-9B4F-EC6319CC90D3")]
-    class RResultsMsg : SerializerClient<RResultsMsg>
+    [DataContract(Name = "ShutdownMsg")]
+    [Guid("09996E36-3FA7-4930-A5BF-61C2D1335A1A")]
+    public sealed class ShutdownMsg : SerializerClient<ShutdownMsg>
     {
         [DataMember]
-        public Guid Id { get; set;  }
+        public Guid Id { get; set; }
 
-        [DataMember]
-        public string Value { get; set; }
-
-        public static RResultsMsg Factory(Guid id, string value)
+        public static ShutdownMsg Factory()
         {
-            RResultsMsg message = new RResultsMsg();
-            message.Id = id;
-            message.Value = value;
-            return message;
+            ShutdownMsg shutdown = new ShutdownMsg();
+            shutdown.Id = Guid.NewGuid();
+            return shutdown;
         }
 
         public override string ToString()
         {
-            return string.Format("RResultsMsg[{0}] value = [{1}]", Id.ToString(), Value);
+            return string.Format("ShutdownMsg[{0}]", Id.ToString());
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.DistributedR/Org.Apache.REEF.DistributedR.csproj
+++ b/lang/cs/Org.Apache.REEF.DistributedR/Org.Apache.REEF.DistributedR.csproj
@@ -43,12 +43,12 @@
     <Compile Include="DriverProxy.cs" />
     <Compile Include="Configuration\DriverProxyConfigurationProvider.cs" />
     <Compile Include="Network\Header.cs" />
-    <Compile Include="Network\IReceiver.cs" />
     <Compile Include="Network\Message.cs" />
     <Compile Include="Network\MessageHandler.cs" />
     <Compile Include="Network\Serializer.cs" />
     <Compile Include="Network\RResults.cs" />
     <Compile Include="Network\RTaskMsg.cs" />
+    <Compile Include="Network\ShutdownMsg.cs" />
     <Compile Include="SpinTask.cs" />
     <Compile Include="TaskRunner.cs" />
     <Compile Include="Network\MessageService.cs" />


### PR DESCRIPTION
  -Task results message identifiers now match the id of the origin task
   message.
  -A shutdown message is sent to the bridge to enable clean shutdown.

  https://github.com/dougmsft/reef/issues/10