### PR TITLE
Use dependency injection in ProtocolSerializer and around

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge.CLR/Network.cs
+++ b/lang/cs/Org.Apache.REEF.Bridge.CLR/Network.cs
@@ -34,7 +34,6 @@ namespace Org.Apache.REEF.Bridge
     /// Protocol Serializer to provide a simple send/receive interface
     /// between the CLR and Java bridges. 
     /// </summary>
-    [DefaultImplementation(typeof(Network), "Network")]
     public sealed class Network
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(Network));

--- a/lang/cs/Org.Apache.REEF.Bridge.CLR/Network.cs
+++ b/lang/cs/Org.Apache.REEF.Bridge.CLR/Network.cs
@@ -22,7 +22,6 @@ using System.Net;
 using org.apache.reef.bridge.message;
 using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Avro;
 using Org.Apache.REEF.Wake.Remote;

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeConfigurationProvider.cs
@@ -140,19 +140,19 @@ namespace Org.Apache.REEF.Driver.Bridge
         /// Instantiates an IInjector using the bridge configuration.
         /// </summary>
         /// <returns></returns>
-        internal static IInjector GetBridgeInjector(IEvaluatorRequestor evaluatorRequestor, params IConfiguration[] otherConfigs)
+        internal static IInjector GetBridgeInjector(
+            IEvaluatorRequestor evaluatorRequestor, params IConfiguration[] otherConfigs)
         {
             lock (LockObject)
             {
                 if (bridgeInjector == null)
                 {
-                    IConfiguration config = Configurations.Merge(
+                    bridgeInjector = TangFactory.GetTang().NewInjector(
                         Configurations.Merge(otherConfigs), GetBridgeConfiguration());
 
-                    bridgeInjector = TangFactory.GetTang().NewInjector(config);
                     if (evaluatorRequestor != null)
                     {
-                        bridgeInjector.BindVolatileInstance(GenericType<IEvaluatorRequestor>.Class, evaluatorRequestor);
+                        bridgeInjector.BindVolatileInstance(evaluatorRequestor);
                     }
                 }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
@@ -32,6 +32,7 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Bridge;
+using Org.Apache.REEF.Wake.Avro;
 
 namespace Org.Apache.REEF.Driver.Bridge
 {
@@ -286,10 +287,8 @@ namespace Org.Apache.REEF.Driver.Bridge
             try
             {
                 IConfiguration clrConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                    .BindStringNamedParam<ProtocolSerializerParameters.AssemblyName>(typeof(Network).Assembly.FullName)
-                    .BindStringNamedParam<ProtocolSerializerParameters.MessageNamespace>("org.apache.reef.bridge.message")
-                    .BindNamedParameter<LocalObserverParameters.MessageObserver, ClrBridge, object>(
-                        GenericType<LocalObserverParameters.MessageObserver>.Class, impl: GenericType<ClrBridge>.Class)
+                    .BindStringNamedParam<ProtocolSerializer.AssemblyName>(typeof(Network).Assembly.FullName)
+                    .BindStringNamedParam<ProtocolSerializer.MessageNamespace>("org.apache.reef.bridge.message")
                     .Build();
 
                 var driverBridgeInjector =

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -26,6 +26,7 @@ using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Examples.HelloREEF
 {
@@ -64,6 +65,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                 .AddDriverConfiguration(helloDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloDriver))
                 .SetJobIdentifier("HelloREEF")
+                .SetJavaLogLevel(JavaLoggingSetting.Verbose)
                 .Build();
 
             _reefClient.Submit(helloJobRequest);

--- a/lang/cs/Org.Apache.REEF.Wake/Avro/ProtocolSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Avro/ProtocolSerializer.cs
@@ -24,19 +24,6 @@ using Org.Apache.REEF.Utilities.Logging;
 using org.apache.reef.wake.avro.message;
 using Org.Apache.REEF.Tang.Annotations;
 
-public sealed class ProtocolSerializerParameters
-{
-    [NamedParameter(DefaultClass = typeof(string))]
-    public class AssemblyName : Name<string>
-    {
-    }
-
-    [NamedParameter(DefaultClass = typeof(string))]
-    public class MessageNamespace : Name<string>
-    {
-    }
-}
-
 namespace Org.Apache.REEF.Wake.Avro
 {
     /// <summary>
@@ -48,6 +35,16 @@ namespace Org.Apache.REEF.Wake.Avro
     /// </summary>
     public sealed class ProtocolSerializer
     {
+        [NamedParameter("Name of the assembly that contains serializable classes.")]
+        public class AssemblyName : Name<string>
+        {
+        }
+
+        [NamedParameter("Package name to search for serializabe classes.")]
+        public class MessageNamespace : Name<string>
+        {
+        }
+
         private static readonly Logger Logr = Logger.GetLogger(typeof(ProtocolSerializer));
 
         /// <summary>
@@ -88,8 +85,8 @@ namespace Org.Apache.REEF.Wake.Avro
         /// <param name="messageNamespace">A string which contains the namespace the protocol messages.</param>
         [Inject]
         public ProtocolSerializer(
-            [Parameter(typeof(ProtocolSerializerParameters.AssemblyName))] string assemblyName,
-            [Parameter(typeof(ProtocolSerializerParameters.MessageNamespace))] string messageNamespace)
+            [Parameter(typeof(AssemblyName))] string assemblyName,
+            [Parameter(typeof(MessageNamespace))] string messageNamespace)
         {
             Logr.Log(Level.Verbose, "Retrieving types for assembly: {0}", assemblyName);
             Assembly assembly = Assembly.Load(assemblyName);

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
@@ -25,6 +25,8 @@ import org.apache.reef.io.network.naming.NameServerConfiguration;
 import org.apache.reef.javabridge.generic.JobDriver;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.webserver.HttpHandlerConfiguration;
 import org.apache.reef.webserver.HttpServerReefEventHandler;
 import org.apache.reef.webserver.ReefEventStateManager;
@@ -52,6 +54,10 @@ public final class Constants {
       .set(DriverConfiguration.ON_TASK_SUSPENDED, JobDriver.SuspendedTaskHandler.class)
       .set(DriverConfiguration.ON_EVALUATOR_COMPLETED, JobDriver.CompletedEvaluatorHandler.class)
       .set(DriverConfiguration.PROGRESS_PROVIDER, JobDriver.ProgressProvider.class)
+      .build();
+
+  private static final Configuration BRIDGE_CONFIGURATION = Tang.Factory.getTang().newConfigurationBuilder()
+      .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
       .build();
 
   /**
@@ -91,6 +97,7 @@ public final class Constants {
    */
   public static final Configuration DRIVER_CONFIGURATION_WITH_HTTP_AND_NAMESERVER = Configurations.merge(
       DRIVER_CONFIGURATION,
+      BRIDGE_CONFIGURATION,
       HTTP_SERVER_CONFIGURATION,
       NAME_SERVER_CONFIGURATION
   );

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.bridge.client;
 
+import org.apache.reef.bridge.JavaBridge;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverServiceConfiguration;
 import org.apache.reef.client.DriverRestartConfiguration;
@@ -26,6 +27,7 @@ import org.apache.reef.javabridge.generic.JobDriver;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
+import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.webserver.HttpHandlerConfiguration;
 import org.apache.reef.webserver.HttpServerReefEventHandler;
@@ -58,6 +60,7 @@ public final class Constants {
 
   private static final Configuration BRIDGE_CONFIGURATION = Tang.Factory.getTang().newConfigurationBuilder()
       .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
+      .bindImplementation(MultiObserver.class, JavaBridge.class)
       .build();
 
   /**

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
@@ -23,6 +23,7 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
+import org.apache.reef.bridge.JavaBridge;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.io.TcpPortConfigurationProvider;
 import org.apache.reef.reef.bridge.client.avro.AvroAppSubmissionParameters;
@@ -35,6 +36,7 @@ import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
+import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.wake.remote.address.LoopbackLocalAddressProvider;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
@@ -117,6 +119,7 @@ final class LocalSubmissionFromCS {
         .bindNamedParameter(JobSubmissionDirectory.class, runtimeRootFolder.getAbsolutePath())
         .bindList(DriverLaunchCommandPrefix.class, driverLaunchCommandPrefixList)
         .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
+        .bindImplementation(MultiObserver.class, JavaBridge.class)
         .build();
 
     return Configurations.merge(runtimeConfiguration, userProviderConfiguration);

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
@@ -35,6 +35,7 @@ import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
+import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.wake.remote.address.LoopbackLocalAddressProvider;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
@@ -115,6 +116,7 @@ final class LocalSubmissionFromCS {
         .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(tcpTryCount))
         .bindNamedParameter(JobSubmissionDirectory.class, runtimeRootFolder.getAbsolutePath())
         .bindList(DriverLaunchCommandPrefix.class, driverLaunchCommandPrefixList)
+        .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
         .build();
 
     return Configurations.merge(runtimeConfiguration, userProviderConfiguration);

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/MultiRuntimeYarnBootstrapDriverConfigGenerator.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/MultiRuntimeYarnBootstrapDriverConfigGenerator.java
@@ -20,6 +20,7 @@ package org.apache.reef.bridge.client;
 
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.bridge.JavaBridge;
 import org.apache.reef.client.DriverRestartConfiguration;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.io.TcpPortConfigurationProvider;
@@ -41,6 +42,7 @@ import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
@@ -223,6 +225,7 @@ final class MultiRuntimeYarnBootstrapDriverConfigGenerator {
             .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
             .bindConstructor(YarnConfiguration.class, YarnConfigurationConstructor.class)
             .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
+            .bindImplementation(MultiObserver.class, JavaBridge.class)
             .build();
 
     final Configuration driverConfiguration = Configurations.merge(

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/MultiRuntimeYarnBootstrapDriverConfigGenerator.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/MultiRuntimeYarnBootstrapDriverConfigGenerator.java
@@ -41,6 +41,7 @@ import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
@@ -140,6 +141,7 @@ final class MultiRuntimeYarnBootstrapDriverConfigGenerator {
           final AvroLocalAppSubmissionParameters localAppSubmissionParams,
           final AvroJobSubmissionParameters jobSubmissionParameters,
           final MultiRuntimeDefinitionBuilder builder) {
+
     // create and serialize local configuration if defined
     final Configuration localModule = LocalDriverConfiguration.CONF
             .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS,
@@ -163,7 +165,7 @@ final class MultiRuntimeYarnBootstrapDriverConfigGenerator {
           final AvroMultiRuntimeAppSubmissionParameters multiruntimeAppSubmissionParams) {
 
     if (multiruntimeAppSubmissionParams.getLocalRuntimeAppParameters() == null &&
-            multiruntimeAppSubmissionParams.getYarnRuntimeAppParameters() == null){
+            multiruntimeAppSubmissionParams.getYarnRuntimeAppParameters() == null) {
       throw new IllegalArgumentException("At least on execution runtime has to be provided");
     }
 
@@ -174,13 +176,13 @@ final class MultiRuntimeYarnBootstrapDriverConfigGenerator {
     // generate multi runtime definition
     final MultiRuntimeDefinitionBuilder multiRuntimeDefinitionBuilder = new MultiRuntimeDefinitionBuilder();
 
-    if (multiruntimeAppSubmissionParams.getLocalRuntimeAppParameters() != null){
+    if (multiruntimeAppSubmissionParams.getLocalRuntimeAppParameters() != null) {
       addLocalRuntimeDefinition(
               multiruntimeAppSubmissionParams.getLocalRuntimeAppParameters(),
               jobSubmissionParameters, multiRuntimeDefinitionBuilder);
     }
 
-    if (multiruntimeAppSubmissionParams.getYarnRuntimeAppParameters() != null){
+    if (multiruntimeAppSubmissionParams.getYarnRuntimeAppParameters() != null) {
       addYarnRuntimeDefinition(
               yarnJobSubmissionParams,
               jobSubmissionParameters,
@@ -220,6 +222,7 @@ final class MultiRuntimeYarnBootstrapDriverConfigGenerator {
                     yarnJobSubmissionParams.getJobSubmissionDirectoryPrefix().toString())
             .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
             .bindConstructor(YarnConfiguration.class, YarnConfigurationConstructor.class)
+            .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
             .build();
 
     final Configuration driverConfiguration = Configurations.merge(
@@ -230,6 +233,7 @@ final class MultiRuntimeYarnBootstrapDriverConfigGenerator {
     // add restart configuration if needed
     if (multiruntimeAppSubmissionParams.getYarnRuntimeAppParameters() != null &&
             multiruntimeAppSubmissionParams.getYarnRuntimeAppParameters().getDriverRecoveryTimeout() > 0) {
+
       LOG.log(Level.FINE, "Driver restart is enabled.");
 
       final Configuration yarnDriverRestartConfiguration =

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnBootstrapDriverConfigGenerator.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnBootstrapDriverConfigGenerator.java
@@ -38,6 +38,7 @@ import org.apache.reef.runtime.yarn.driver.parameters.FileSystemUrl;
 import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectoryPrefix;
 import org.apache.reef.tang.*;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
@@ -92,6 +93,7 @@ final class YarnBootstrapDriverConfigGenerator {
 
     final AvroJobSubmissionParameters jobSubmissionParameters =
         yarnJobSubmissionParams.getSharedJobSubmissionParameters();
+
     final Configuration yarnDriverConfiguration = YarnDriverConfiguration.CONF
         .set(YarnDriverConfiguration.JOB_SUBMISSION_DIRECTORY,
             yarnJobSubmissionParams.getDfsJobSubmissionFolder().toString())
@@ -110,8 +112,8 @@ final class YarnBootstrapDriverConfigGenerator {
         .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(appSubmissionParams.getTcpTryCount()))
         .bindNamedParameter(JobSubmissionDirectoryPrefix.class,
             yarnJobSubmissionParams.getJobSubmissionDirectoryPrefix().toString())
-        .bindNamedParameter(FileSystemUrl.class,
-            yarnJobSubmissionParams.getFileSystemUrl().toString())
+        .bindNamedParameter(FileSystemUrl.class, yarnJobSubmissionParams.getFileSystemUrl().toString())
+        .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
         .build();
 
     final Configuration driverConfiguration = Configurations.merge(

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnBootstrapDriverConfigGenerator.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnBootstrapDriverConfigGenerator.java
@@ -21,6 +21,7 @@ package org.apache.reef.bridge.client;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.reef.bridge.JavaBridge;
 import org.apache.reef.client.DriverRestartConfiguration;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.io.TcpPortConfigurationProvider;
@@ -38,6 +39,7 @@ import org.apache.reef.runtime.yarn.driver.parameters.FileSystemUrl;
 import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectoryPrefix;
 import org.apache.reef.tang.*;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
@@ -114,6 +116,7 @@ final class YarnBootstrapDriverConfigGenerator {
             yarnJobSubmissionParams.getJobSubmissionDirectoryPrefix().toString())
         .bindNamedParameter(FileSystemUrl.class, yarnJobSubmissionParams.getFileSystemUrl().toString())
         .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
+        .bindImplementation(MultiObserver.class, JavaBridge.class)
         .build();
 
     final Configuration driverConfiguration = Configurations.merge(

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
@@ -24,6 +24,8 @@ import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializer;
 import org.apache.reef.wake.remote.RemoteMessage;
+import org.apache.reef.wake.remote.address.LocalAddressProvider;
+import org.apache.reef.wake.remote.impl.ByteCodec;
 import org.apache.reef.wake.remote.impl.SocketRemoteIdentifier;
 import org.apache.reef.wake.remote.RemoteIdentifier;
 import org.apache.reef.wake.remote.RemoteManager;
@@ -59,14 +61,17 @@ public final class Network {
   @Inject
   public Network(
       final RemoteManagerFactory remoteManagerFactory,
+      final LocalAddressProvider localAddressProvider,
       final ProtocolSerializer serializer,
       final InjectionFuture<MultiObserver> observer) {
 
     LOG.log(Level.INFO, "Initializing");
 
-    this.remoteManager = remoteManagerFactory.getInstance("JavaBridgeNetwork");
     this.serializer = serializer;
     this.messageObserver = observer;
+
+    this.remoteManager = remoteManagerFactory.getInstance(
+        "JavaBridgeNetwork", localAddressProvider.getLocalAddress(), 0, new ByteCodec());
 
     // Get our address and port number.
     final RemoteIdentifier remoteIdentifier = this.remoteManager.getMyIdentifier();

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
@@ -90,7 +90,7 @@ public final class Network {
       sender.onNext(serializer.write(message, identifier));
     } else {
       LOG.log(Level.SEVERE,
-          "Attempt to send message [{0}] before network is initialized", message.getClass().getName());
+          "Attempt to send message [{0}] before network is initialized", message.getClass().getCanonicalName());
     }
   }
 

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
@@ -19,6 +19,7 @@
 package org.apache.reef.bridge;
 
 import org.apache.avro.specific.SpecificRecord;
+import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializer;
@@ -47,7 +48,7 @@ public final class Network {
 
   private final ProtocolSerializer serializer;
   private final InetSocketAddress inetSocketAddress;
-  private final MultiObserver messageObserver;
+  private final InjectionFuture<MultiObserver> messageObserver;
 
   private EventHandler<byte[]> sender;
 
@@ -59,7 +60,7 @@ public final class Network {
   public Network(
       final RemoteManagerFactory remoteManagerFactory,
       final ProtocolSerializer serializer,
-      final MultiObserver observer) {
+      final InjectionFuture<MultiObserver> observer) {
 
     LOG.log(Level.INFO, "Initializing");
 
@@ -125,7 +126,7 @@ public final class Network {
       }
 
       // Deserialize the message and invoke the appropriate processing method.
-      serializer.read(message.getMessage(), messageObserver);
+      serializer.read(message.getMessage(), messageObserver.get());
     }
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/bridge/Network.java
@@ -19,24 +19,17 @@
 package org.apache.reef.bridge;
 
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.reef.tang.Injector;
-import org.apache.reef.tang.Tang;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializer;
 import org.apache.reef.wake.remote.RemoteMessage;
-import org.apache.reef.wake.remote.impl.ByteCodec;
 import org.apache.reef.wake.remote.impl.SocketRemoteIdentifier;
 import org.apache.reef.wake.remote.RemoteIdentifier;
 import org.apache.reef.wake.remote.RemoteManager;
 import org.apache.reef.wake.remote.RemoteManagerFactory;
-import org.apache.reef.wake.remote.ports.TcpPortProvider;
-import org.apache.reef.wake.impl.LoggingEventHandler;
-import org.apache.reef.wake.remote.address.LocalAddressProvider;
 
 import javax.inject.Inject;
 import java.net.InetSocketAddress;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,59 +39,45 @@ import java.util.logging.Logger;
  * between the Java and CLR sides of the bridge.
  */
 public final class Network {
-  private static final Logger LOG = Logger.getLogger(Network.class.getName());
-  private static final AtomicLong IDENTIFIER_SOURCE = new AtomicLong(0);
 
+  private static final Logger LOG = Logger.getLogger(Network.class.getName());
+
+  /** Remote manager to handle java-C# bridge communication. */
   private RemoteManager remoteManager;
-  private InetSocketAddress inetSocketAddress;
+
+  private final ProtocolSerializer serializer;
+  private final InetSocketAddress inetSocketAddress;
+  private final MultiObserver messageObserver;
+
   private EventHandler<byte[]> sender;
-  private final LocalObserver localObserver;
-  private final ProtocolSerializer serializer = new ProtocolSerializer("org.apache.reef.bridge.message");
 
   /**
    * Sends and receives messages between the java bridge and C# bridge.
-   * @param localAddressProvider Local address provider used to find open port.
    * @param observer A multiobserver instance that will receive all incoming messages.
    */
   @Inject
-  public Network(final LocalAddressProvider localAddressProvider, final MultiObserver observer) {
+  public Network(
+      final RemoteManagerFactory remoteManagerFactory,
+      final ProtocolSerializer serializer,
+      final MultiObserver observer) {
+
     LOG.log(Level.INFO, "Initializing");
 
-    this.localObserver = new LocalObserver(this, observer);
+    this.remoteManager = remoteManagerFactory.getInstance("JavaBridgeNetwork");
+    this.serializer = serializer;
+    this.messageObserver = observer;
 
-    try {
-      String name = "JavaBridgeNetwork";
-      int port = 0;
-      boolean order = true;
-      int retries = 3;
-      int timeOut = 10000;
-
-      // Instantiate a port provider.
-      final Injector injector = Tang.Factory.getTang().newInjector();
-      final TcpPortProvider tcpPortProvider = injector.getInstance(TcpPortProvider.class);
-
-      // Instantiate a remote manager to handle java-C# bridge communication.
-      final RemoteManagerFactory remoteManagerFactory = injector.getInstance(RemoteManagerFactory.class);
-      remoteManager = remoteManagerFactory.getInstance(
-        name, localAddressProvider.getLocalAddress(), port, new ByteCodec(),
-        new LoggingEventHandler<Throwable>(), order, retries, timeOut,
-        localAddressProvider, tcpPortProvider);
-
-      // Get our address and port number.
-      final RemoteIdentifier remoteIdentifier = remoteManager.getMyIdentifier();
-      if (remoteIdentifier instanceof SocketRemoteIdentifier) {
-        SocketRemoteIdentifier socketIdentifier = (SocketRemoteIdentifier)remoteIdentifier;
-        inetSocketAddress = socketIdentifier.getSocketAddress();
-      } else {
-        throw new RuntimeException("Identifier is not a SocketRemoteIdentifier");
-      }
-
-      // Register as the message handler for any incoming messages.
-      remoteManager.registerHandler(byte[].class, this.localObserver);
-
-    } catch (final Exception e) {
-      LOG.log(Level.SEVERE, "Initialization failed: ", e);
+    // Get our address and port number.
+    final RemoteIdentifier remoteIdentifier = this.remoteManager.getMyIdentifier();
+    if (remoteIdentifier instanceof SocketRemoteIdentifier) {
+      final SocketRemoteIdentifier socketIdentifier = (SocketRemoteIdentifier)remoteIdentifier;
+      this.inetSocketAddress = socketIdentifier.getSocketAddress();
+    } else {
+      throw new RuntimeException("Identifier is not a SocketRemoteIdentifier: " + remoteIdentifier);
     }
+
+    // Register as the message handler for any incoming messages.
+    this.remoteManager.registerHandler(byte[].class, new LocalObserver());
   }
 
   /**
@@ -125,35 +104,24 @@ public final class Network {
   /**
    * Processes messages from the network remote manager.
    */
-  private class LocalObserver implements EventHandler<RemoteMessage<byte[]>> {
-    private final Network network;
-    private final MultiObserver messageObserver;
-
-    /**
-     * Associate the local observer with the specified network and message observer.
-     * @param network
-     * @param messageObserver
-     */
-    LocalObserver(final Network network, final MultiObserver messageObserver) {
-      this.network = network;
-      this.messageObserver = messageObserver;
-    }
+  private final class LocalObserver implements EventHandler<RemoteMessage<byte[]>> {
 
     /**
      * Deserialize and direct incoming messages to the registered MuiltiObserver event handler.
      * @param message A RemoteMessage<byte[]> object which will be deserialized.
      */
+    @Override
     public void onNext(final RemoteMessage<byte[]> message) {
       LOG.log(Level.INFO, "Received remote message: {0}", message);
 
-      if (network.sender == null) {
+      if (sender == null) {
         // Instantiate a network connection to the C# side of the bridge.
         // THERE COULD BE  A SECURITY ISSUE HERE WHERE SOMEONE SPOOFS THE
         // C# BRIDGE, WE RECEIVE IT FIRST, AND CONNECT TO THE SPOOFER,
         // THOUGH THE TIME WINDOW IS VERY SMALL.
         final RemoteIdentifier remoteIdentifier = message.getIdentifier();
         LOG.log(Level.INFO, "Connecting to: {0}", remoteIdentifier);
-        network.sender = remoteManager.getHandler(remoteIdentifier, byte[].class);
+        sender = remoteManager.getHandler(remoteIdentifier, byte[].class);
       }
 
       // Deserialize the message and invoke the appropriate processing method.

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
@@ -24,14 +24,15 @@ import org.apache.reef.javabridge.NativeInterop;
 import org.apache.reef.runtime.yarn.driver.YarnDriverRestartConfiguration;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Unit;
-import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.util.EnvironmentUtils;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.webserver.HttpHandlerConfiguration;
 import org.apache.reef.webserver.HttpServerReefEventHandler;
 import org.apache.reef.webserver.ReefEventStateManager;
@@ -50,7 +51,7 @@ import java.util.logging.Logger;
  * Clr Bridge Client.
  */
 @Unit
-public class JobClient {
+public final class JobClient {
 
   /**
    * Standard java logger.
@@ -62,12 +63,6 @@ public class JobClient {
    * This variable is injected automatically in the constructor.
    */
   private final REEF reef;
-
-  /**
-   * Job Driver configuration.
-   */
-  private Configuration driverConfiguration;
-  private ConfigurationModule driverConfigModule;
 
   /**
    * A reference to the running job that allows client to send messages back to the job driver.
@@ -89,6 +84,7 @@ public class JobClient {
    * A factory that provides LoggingScope.
    */
   private final LoggingScopeFactory loggingScopeFactory;
+
   /**
    * Clr Bridge client.
    * Parameters are injected automatically by TANG.
@@ -96,28 +92,9 @@ public class JobClient {
    * @param reef Reference to the REEF framework.
    */
   @Inject
-  JobClient(final REEF reef, final LoggingScopeFactory loggingScopeFactory) throws BindException {
+  private JobClient(final REEF reef, final LoggingScopeFactory loggingScopeFactory) {
     this.loggingScopeFactory = loggingScopeFactory;
     this.reef = reef;
-    this.driverConfigModule = getDriverConfiguration();
-  }
-
-  public static ConfigurationModule getDriverConfiguration() {
-    return DriverConfiguration.CONF
-        .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())
-        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, JobDriver.AllocatedEvaluatorHandler.class)
-        .set(DriverConfiguration.ON_EVALUATOR_FAILED, JobDriver.FailedEvaluatorHandler.class)
-        .set(DriverConfiguration.ON_CONTEXT_ACTIVE, JobDriver.ActiveContextHandler.class)
-        .set(DriverConfiguration.ON_CONTEXT_CLOSED, JobDriver.ClosedContextHandler.class)
-        .set(DriverConfiguration.ON_CONTEXT_FAILED, JobDriver.FailedContextHandler.class)
-        .set(DriverConfiguration.ON_CONTEXT_MESSAGE, JobDriver.ContextMessageHandler.class)
-        .set(DriverConfiguration.ON_TASK_MESSAGE, JobDriver.TaskMessageHandler.class)
-        .set(DriverConfiguration.ON_TASK_FAILED, JobDriver.FailedTaskHandler.class)
-        .set(DriverConfiguration.ON_TASK_RUNNING, JobDriver.RunningTaskHandler.class)
-        .set(DriverConfiguration.ON_TASK_COMPLETED, JobDriver.CompletedTaskHandler.class)
-        .set(DriverConfiguration.ON_DRIVER_STARTED, JobDriver.StartHandler.class)
-        .set(DriverConfiguration.ON_TASK_SUSPENDED, JobDriver.SuspendedTaskHandler.class)
-        .set(DriverConfiguration.ON_EVALUATOR_COMPLETED, JobDriver.CompletedEvaluatorHandler.class);
   }
 
   private static Configuration getNameServerConfiguration() {
@@ -129,7 +106,8 @@ public class JobClient {
   /**
    * @return the driver-side configuration to be merged into the DriverConfiguration to enable the HTTP server.
    */
-  public static Configuration getHTTPConfiguration() {
+  private static Configuration getHTTPConfiguration() {
+
     final Configuration httpHandlerConfiguration = HttpHandlerConfiguration.CONF
         .set(HttpHandlerConfiguration.HTTP_HANDLERS, HttpServerReefEventHandler.class)
         .build();
@@ -146,7 +124,8 @@ public class JobClient {
     return Configurations.merge(httpHandlerConfiguration, driverConfigurationForHttpServer);
   }
 
-  public static Configuration getYarnConfiguration() {
+  private static Configuration getYarnConfiguration() {
+
     final Configuration yarnDriverRestartConfiguration = YarnDriverRestartConfiguration.CONF
         .build();
 
@@ -162,45 +141,61 @@ public class JobClient {
     return Configurations.merge(yarnDriverRestartConfiguration, driverRestartHandlerConfigurations);
   }
 
-  public void addCLRFiles(final File folder) throws BindException {
-    try (final LoggingScope ls = this.loggingScopeFactory.getNewLoggingScope("JobClient::addCLRFiles")) {
-      ConfigurationModule result = this.driverConfigModule;
+  private Configuration getDriverConfiguration(final File folder) {
+
+    final Configuration bridgeConfig = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
+        .build();
+
+    ConfigurationModule driverConfigModule = DriverConfiguration.CONF
+        .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, JobDriver.AllocatedEvaluatorHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_FAILED, JobDriver.FailedEvaluatorHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_ACTIVE, JobDriver.ActiveContextHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_CLOSED, JobDriver.ClosedContextHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_FAILED, JobDriver.FailedContextHandler.class)
+        .set(DriverConfiguration.ON_CONTEXT_MESSAGE, JobDriver.ContextMessageHandler.class)
+        .set(DriverConfiguration.ON_TASK_MESSAGE, JobDriver.TaskMessageHandler.class)
+        .set(DriverConfiguration.ON_TASK_FAILED, JobDriver.FailedTaskHandler.class)
+        .set(DriverConfiguration.ON_TASK_RUNNING, JobDriver.RunningTaskHandler.class)
+        .set(DriverConfiguration.ON_TASK_COMPLETED, JobDriver.CompletedTaskHandler.class)
+        .set(DriverConfiguration.ON_DRIVER_STARTED, JobDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_TASK_SUSPENDED, JobDriver.SuspendedTaskHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_COMPLETED, JobDriver.CompletedEvaluatorHandler.class)
+        .set(DriverConfiguration.DRIVER_MEMORY, this.driverMemory)
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, this.driverId)
+        .set(DriverConfiguration.DRIVER_JOB_SUBMISSION_DIRECTORY, this.jobSubmissionDirectory);
+
+    try (final LoggingScope ls = this.loggingScopeFactory.getNewLoggingScope("JobClient::getDriverConfiguration")) {
+
       final File[] files = folder.listFiles();
       if (files != null) {
         for (final File f : files) {
           if (f.canRead() && f.exists() && f.isFile()) {
-            result = result.set(DriverConfiguration.GLOBAL_FILES, f.getAbsolutePath());
+            driverConfigModule = driverConfigModule.set(DriverConfiguration.GLOBAL_FILES, f.getAbsolutePath());
           }
         }
       }
-
-      // set the driver memory, id and job submission directory
-      this.driverConfigModule = result
-          .set(DriverConfiguration.DRIVER_MEMORY, this.driverMemory)
-          .set(DriverConfiguration.DRIVER_IDENTIFIER, this.driverId)
-          .set(DriverConfiguration.DRIVER_JOB_SUBMISSION_DIRECTORY, this.jobSubmissionDirectory);
-
 
       final Path globalLibFile = Paths.get(NativeInterop.GLOBAL_LIBRARIES_FILENAME);
       if (!Files.exists(globalLibFile)) {
         LOG.log(Level.FINE, "Cannot find global classpath file at: {0}, assume there is none.",
             globalLibFile.toAbsolutePath());
       } else {
-        String globalLibString = "";
         try {
-          globalLibString = new String(Files.readAllBytes(globalLibFile), StandardCharsets.UTF_8);
+          final String globalLibString = new String(Files.readAllBytes(globalLibFile), StandardCharsets.UTF_8);
+          for (final String fileName : globalLibString.split(",")) {
+            driverConfigModule = driverConfigModule.set(
+                DriverConfiguration.GLOBAL_LIBRARIES, new File(fileName).getPath());
+          }
         } catch (final Exception e) {
-          LOG.log(Level.WARNING, "Cannot read from {0}, global libraries not added  " + globalLibFile.toAbsolutePath());
-        }
-
-        for (final String s : globalLibString.split(",")) {
-          final File f = new File(s);
-          this.driverConfigModule = this.driverConfigModule.set(DriverConfiguration.GLOBAL_LIBRARIES, f.getPath());
+          LOG.log(Level.WARNING,
+              "Cannot read global libraries from file: " + globalLibFile.toAbsolutePath(), e);
         }
       }
 
-      this.driverConfiguration = Configurations.merge(this.driverConfigModule.build(), getHTTPConfiguration(),
-          getNameServerConfiguration());
+      return Configurations.merge(
+          driverConfigModule.build(), bridgeConfig, getHTTPConfiguration(), getNameServerConfiguration());
     }
   }
 
@@ -211,26 +206,25 @@ public class JobClient {
    */
   public void submit(final File clrFolder, final boolean submitDriver,
                      final boolean local, final Configuration clientConfig) {
+
     try (final LoggingScope ls = this.loggingScopeFactory.driverSubmit(submitDriver)) {
+
+      Configuration driverConfig = getDriverConfiguration(clrFolder);
       if (!local) {
-        this.driverConfiguration = Configurations.merge(this.driverConfiguration, getYarnConfiguration());
+        driverConfig = Configurations.merge(driverConfig, getYarnConfiguration());
       }
 
-      try {
-        addCLRFiles(clrFolder);
-      } catch (final BindException e) {
-        LOG.log(Level.FINE, "Failed to bind", e);
-      }
       if (submitDriver) {
-        this.reef.submit(this.driverConfiguration);
+        this.reef.submit(driverConfig);
       } else {
-        final File driverConfig = new File(System.getProperty("user.dir") + "/driver.config");
+        final File driverConfigFile = new File(System.getProperty("user.dir") + "/driver.config");
         try {
-          new AvroConfigurationSerializer().toFile(Configurations.merge(this.driverConfiguration, clientConfig),
-              driverConfig);
-          LOG.log(Level.INFO, "Driver configuration file created at " + driverConfig.getAbsolutePath());
+          new AvroConfigurationSerializer().toFile(
+              Configurations.merge(driverConfig, clientConfig), driverConfigFile);
+          LOG.log(Level.INFO, "Driver configuration file created at " + driverConfigFile.getAbsolutePath());
         } catch (final IOException e) {
-          throw new RuntimeException("Cannot create driver configuration file at " + driverConfig.getAbsolutePath(), e);
+          throw new RuntimeException(
+              "Cannot create driver configuration file at " + driverConfigFile.getAbsolutePath(), e);
         }
       }
     }
@@ -252,7 +246,8 @@ public class JobClient {
     if (jobSubmissionDirectory != null && !jobSubmissionDirectory.equals("empty")) {
       this.jobSubmissionDirectory = jobSubmissionDirectory;
     } else {
-      LOG.log(Level.FINE, "No job submission directory provided by CLR user, will use " + this.jobSubmissionDirectory);
+      LOG.log(Level.FINE,
+          "No job submission directory provided by CLR user, will use {0}", this.jobSubmissionDirectory);
     }
   }
 

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.javabridge.generic;
 
+import org.apache.reef.bridge.JavaBridge;
 import org.apache.reef.client.*;
 import org.apache.reef.io.network.naming.NameServerConfiguration;
 import org.apache.reef.javabridge.NativeInterop;
@@ -32,6 +33,7 @@ import org.apache.reef.util.EnvironmentUtils;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.ProtocolSerializerNamespace;
 import org.apache.reef.webserver.HttpHandlerConfiguration;
 import org.apache.reef.webserver.HttpServerReefEventHandler;
@@ -145,6 +147,7 @@ public final class JobClient {
 
     final Configuration bridgeConfig = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(ProtocolSerializerNamespace.class, "org.apache.reef.bridge.message")
+        .bindImplementation(MultiObserver.class, JavaBridge.class)
         .build();
 
     ConfigurationModule driverConfigModule = DriverConfiguration.CONF

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -36,6 +36,7 @@ import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.util.Optional;
+import org.apache.reef.util.exception.InvalidIdentifierException;
 import org.apache.reef.util.logging.CLRBufferedLogHandler;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
@@ -129,7 +130,7 @@ public final class JobDriver {
   // Need to add references here so that GC does not collect them.
   private EvaluatorRequestorBridge evaluatorRequestorBridge;
   private final Map<String, AllocatedEvaluatorBridge> allocatedEvaluatorBridges = new HashMap<>();
-  private JavaBridge bridge;
+  private final JavaBridge bridge;
 
 
   /**
@@ -623,8 +624,9 @@ public final class JobDriver {
 
         try {
           bridge.callClrSystemOnStartHandler();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
+        } catch (final InvalidIdentifierException | InterruptedException e) {
+          LOG.log(Level.SEVERE, "CLR bridge error", e);
+          throw new RuntimeException("CLR bridge error", e);
         }
         LOG.log(Level.INFO, "Driver Started");
       }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -187,6 +187,7 @@ public final class JobDriver {
       }
 
       // Write the webserver ip address and port number to a file for the C# side.
+      LOG.log(Level.INFO, "Write HTTP endpoint to: {0}", reefFileNames.getDriverHttpEndpoint());
       final String httpPortNumber = httpServer == null ? null : Integer.toString(httpServer.getPort());
       if (httpPortNumber != null) {
         try {
@@ -202,16 +203,21 @@ public final class JobDriver {
       }
 
       // Write the java bridge ip address and port number to a file for the C# side.
-      final InetSocketAddress javaBridgeAddress = bridge.getAddress();
-      final String javaBridgePort = Integer.toString(javaBridgeAddress.getPort());
+      LOG.log(Level.INFO, "Write java bridge endpoint to: {0}", reefFileNames.getDriverJavaBridgeEndpoint());
       try {
+        final InetSocketAddress javaBridgeAddress = bridge.getAddress();
+        final String javaBridgePort = Integer.toString(javaBridgeAddress.getPort());
+
+        final String address = localAddressProvider.getLocalAddress() + ":" + javaBridgePort;
         final File outputFileName = new File(reefFileNames.getDriverJavaBridgeEndpoint());
-        try(final BufferedWriter out = new BufferedWriter(
+
+        try (final BufferedWriter out = new BufferedWriter(
               new OutputStreamWriter(new FileOutputStream(outputFileName), StandardCharsets.UTF_8))) {
-          final String address = localAddressProvider.getLocalAddress() + ":" + javaBridgePort;
-          LOG.log(Level.INFO, "Java bridge address: {0}", address);
           out.write(address + "\n");
         }
+
+        LOG.log(Level.INFO, "Java bridge address: {0}", address);
+
       } catch (IOException ex) {
         throw new RuntimeException(
             "Error writing bridge endpoint to: " + reefFileNames.getDriverJavaBridgeEndpoint(), ex);

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -202,14 +202,14 @@ public final class JobDriver {
       }
 
       // Write the java bridge ip address and port number to a file for the C# side.
-      InetSocketAddress javaBridgeAddress = bridge.getAddress();
+      final InetSocketAddress javaBridgeAddress = bridge.getAddress();
       final String javaBridgePort = Integer.toString(javaBridgeAddress.getPort());
       try {
         final File outputFileName = new File(reefFileNames.getDriverJavaBridgeEndpoint());
         try(final BufferedWriter out = new BufferedWriter(
               new OutputStreamWriter(new FileOutputStream(outputFileName), StandardCharsets.UTF_8))) {
           final String address = localAddressProvider.getLocalAddress() + ":" + javaBridgePort;
-          LOG.log(Level.INFO, "Java bridge address: " + address);
+          LOG.log(Level.INFO, "Java bridge address: {0}", address);
           out.write(address + "\n");
         }
       } catch (IOException ex) {

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/MultiAsyncToSyncTest.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/MultiAsyncToSyncTest.java
@@ -279,7 +279,7 @@ public final class MultiAsyncToSyncTest {
 
     try {
       final MultiAsyncToSync asyncToSync = new MultiAsyncToSync(timeoutPeriodSeconds, TimeUnit.SECONDS);
-      FutureTask<Object> syncProc = new FutureTask<>(new Callable<Object>() {
+      final FutureTask<Object> syncProc = new FutureTask<>(new Callable<Object>() {
         public Object call() throws InterruptedException, InvalidIdentifierException {
           asyncToSync.release(identifier);
           return null;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializer.java
@@ -21,12 +21,15 @@ import org.apache.avro.io.*;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.MultiObserver;
 import org.apache.reef.wake.avro.message.Header;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -34,6 +37,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
+
+import javax.inject.Inject;
 
 /**
  * The ProtocolSerializer generates serializers and deserializers for
@@ -43,10 +48,13 @@ import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
  * would sit in the org.foo.me.messages package.
  */
 public final class ProtocolSerializer {
+
   private static final Logger LOG = Logger.getLogger(ProtocolSerializer.class.getName());
+
   // Maps for mapping message class names to serializer and deserializer classes.
   private final Map<String, IMessageSerializer> nameToSerializerMap = new HashMap<>();
   private final Map<String, IMessageDeserializer> nameToDeserializerMap = new HashMap<>();
+
   private final SpecificDatumReader<Header> headerReader = new SpecificDatumReader<>(Header.class);
 
   /**
@@ -54,7 +62,10 @@ public final class ProtocolSerializer {
    * @param messagePackage A string which contains the full name of the
    *                       package containing the protocol messages.
    */
-  public ProtocolSerializer(final String messagePackage) {
+  @Inject
+  private ProtocolSerializer(
+      @Parameter(ProtocolSerializerNamespace.class) final String messagePackage) {
+
     // Build a list of the message reflection classes.
     final ScanResult scanResult = new FastClasspathScanner(messagePackage).scan();
     final List<String> scanNames = scanResult.getNamesOfSubclassesOf(SpecificRecordBase.class);
@@ -63,14 +74,21 @@ public final class ProtocolSerializer {
     // Add the header message from the org.apache.reef.wake.avro.message package.
     messageClasses.add(Header.class);
 
-    try {
-      // Register all of the messages in the specified package.
-      for (final Class<?> cls : messageClasses) {
-        this.register(cls);
-      }
-    } catch (final Exception e) {
-      throw new RuntimeException("Message registration failed", e);
+    // Register all of the messages in the specified package.
+    for (final Class<?> cls : messageClasses) {
+      this.register(cls);
     }
+  }
+
+  /**
+   * Get a canonical string ID of the class. This ID is then used as a key to find
+   * serializer and deserializer of the message payload. We need a separate method
+   * for it to make sure all parties use the same algorithm to get the class ID.
+   * @param clazz class of the message to be serialized/deserialized.
+   * @return canonical string ID of the class.
+   */
+  public static String getClassId(final Class<?> clazz) {
+    return clazz.getCanonicalName();
   }
 
   /**
@@ -79,9 +97,10 @@ public final class ProtocolSerializer {
    * @param <TMessage> The Java type of the message being registered.
    */
   public <TMessage> void register(final Class<TMessage> msgMetaClass) {
-    LOG.log(Level.INFO, "Registering message: {0}", msgMetaClass.getSimpleName());
-    nameToSerializerMap.put(msgMetaClass.getSimpleName(), SerializationFactory.createSerializer(msgMetaClass));
-    nameToDeserializerMap.put(msgMetaClass.getSimpleName(), SerializationFactory.createDeserializer(msgMetaClass));
+    final String classId = getClassId(msgMetaClass);
+    LOG.log(Level.INFO, "Registering message: {0}", classId);
+    this.nameToSerializerMap.put(classId, SerializationFactory.createSerializer(msgMetaClass));
+    this.nameToDeserializerMap.put(classId, SerializationFactory.createDeserializer(msgMetaClass));
   }
 
   /**
@@ -90,18 +109,21 @@ public final class ProtocolSerializer {
    * @param sequence The unique sequence number of the message.
    */
   public byte[] write(final SpecificRecord message, final long sequence) {
-    try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-      final String name = message.getClass().getSimpleName();
-      LOG.log(Level.INFO, "Serializing message: {0}", name);
 
-      final IMessageSerializer serializer = nameToSerializerMap.get(name);
+    final String classId = getClassId(message.getClass());
+    try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+      LOG.log(Level.INFO, "Serializing message: {0}", classId);
+
+      final IMessageSerializer serializer = this.nameToSerializerMap.get(classId);
       if (serializer != null) {
         serializer.serialize(outputStream, message, sequence);
       }
 
       return outputStream.toByteArray();
-    } catch (final Exception e) {
-      throw new RuntimeException("Failure writing message: " + message.getClass().getCanonicalName(), e);
+
+    } catch (final IOException e) {
+      throw new RuntimeException("Failure writing message: " + classId, e);
     }
   }
 
@@ -112,24 +134,29 @@ public final class ProtocolSerializer {
    *                 to process the deserialized message.
    */
   public void read(final byte[] messageBytes, final MultiObserver observer) {
+
     try (final InputStream inputStream = new ByteArrayInputStream(messageBytes)) {
+
       // Binary decoder for both the header and the message.
       final BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
 
       // Read the header message.
-      final Header header = headerReader.read(null, decoder);
-      LOG.log(Level.INFO, "Deserializing Avro message: {0}", header.getClassName());
+      final Header header = this.headerReader.read(null, decoder);
+      final String classId = header.getClassName().toString();
+      LOG.log(Level.INFO, "Deserializing Avro message: {0}", classId);
 
       // Get the appropriate deserializer and deserialize the message.
-      final IMessageDeserializer deserializer = nameToDeserializerMap.get(header.getClassName().toString());
+      final IMessageDeserializer deserializer = this.nameToDeserializerMap.get(classId);
       if (deserializer != null) {
         deserializer.deserialize(decoder, observer, header.getSequence());
       } else {
-        throw new RuntimeException("Request to deserialize unknown message type: " +  header.getClassName());
+        throw new RuntimeException("Request to deserialize unknown message type: " + classId);
       }
 
-    } catch (final Exception e) {
-      throw new RuntimeException("Failure reading message: ", e);
+    } catch (final IOException e) {
+      throw new RuntimeException("Failure reading message", e);
+    } catch (final InvocationTargetException | IllegalAccessException e) {
+      throw new RuntimeException("Error deserializing message body", e);
     }
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializerNamespace.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/ProtocolSerializerNamespace.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.wake.avro;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * ProtocolSerializer parameter: full name of the package containing protocol messages.
+ */
+@NamedParameter(doc = "full name of the package containing protocol messages",
+    short_name = "protocol_serializer_namespace")
+public final class ProtocolSerializerNamespace implements Name<String> {
+  /** Do not instantiate that class. */
+  private ProtocolSerializerNamespace() { }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/impl/MessageSerializerImpl.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/avro/impl/MessageSerializerImpl.java
@@ -23,6 +23,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.reef.wake.avro.IMessageSerializer;
+import org.apache.reef.wake.avro.ProtocolSerializer;
 import org.apache.reef.wake.avro.message.Header;
 
 import java.io.ByteArrayOutputStream;
@@ -43,7 +44,7 @@ public class MessageSerializerImpl<TMessage> implements IMessageSerializer {
    * @param msgMetaClass The reflection class for the message.
    */
   public MessageSerializerImpl(final Class<TMessage> msgMetaClass) {
-    this.msgMetaClassName = msgMetaClass.getSimpleName();
+    this.msgMetaClassName = ProtocolSerializer.getClassId(msgMetaClass);
     this.messageWriter = new SpecificDatumWriter<>(msgMetaClass);
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiObserverImpl.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiObserverImpl.java
@@ -31,10 +31,11 @@ import java.util.logging.Logger;
 /**
  * The MultiObserverImpl class uses reflection to discover which onNext()
  * event processing methods are defined and then map events to them.
- * @param <TSubCls> The subclass derived from MultiObserverImpl.
  */
-public abstract class MultiObserverImpl<TSubCls> implements MultiObserver {
+public abstract class MultiObserverImpl implements MultiObserver {
+
   private static final Logger LOG = Logger.getLogger(MultiObserverImpl.class.getName());
+
   private final Map<String, Method> methodMap = new HashMap<>();
 
   /**
@@ -62,8 +63,8 @@ public abstract class MultiObserverImpl<TSubCls> implements MultiObserver {
    * @param <TEvent> The type of the event being processed.
    */
   private <TEvent> void unimplemented(final long identifier, final TEvent event) {
-    LOG.log(Level.INFO, "Unimplemented event: [{0}]: {1}",
-        new String[]{String.valueOf(identifier), event.getClass().getName()});
+    LOG.log(Level.SEVERE, "Unimplemented event: [{0}]: {1}", new Object[] {identifier, event});
+    throw new RuntimeException("Event not supported: " + event);
   }
 
   /**
@@ -74,13 +75,13 @@ public abstract class MultiObserverImpl<TSubCls> implements MultiObserver {
    */
   @Override
   public <TEvent> void onNext(final long identifier, final TEvent event)
-    throws IllegalAccessException, InvocationTargetException {
+      throws IllegalAccessException, InvocationTargetException {
 
     // Get the reflection method for this call.
     final Method onNext = methodMap.get(event.getClass().getName());
     if (onNext != null) {
       // Process the event.
-      onNext.invoke((TSubCls) this, identifier, event);
+      onNext.invoke(this, identifier, event);
     } else {
       // Log the unprocessed event.
       unimplemented(identifier, event);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultRemoteManagerFactory.java
@@ -34,7 +34,7 @@ import javax.inject.Inject;
  */
 final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
 
-  private final Injector injector;
+  private final Injector injector = Tang.Factory.getTang().newInjector();
 
   private final Codec<?> codec;
   private final EventHandler<Throwable> errorHandler;
@@ -55,7 +55,7 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
       final LocalAddressProvider localAddressProvider,
       final TransportFactory tpFactory,
       final TcpPortProvider tcpPortProvider) {
-    this.injector = Tang.Factory.getTang().newInjector();
+
     this.codec = codec;
     this.errorHandler = errorHandler;
     this.orderingGuarantee = orderingGuarantee;
@@ -67,125 +67,85 @@ final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
   }
 
   @Override
-  public RemoteManager getInstance(final String name) {
-    try {
-      final Injector newInjector = injector.forkInjector();
-      newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
-      newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, this.codec);
-      newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, this.errorHandler);
-      newInjector.bindVolatileParameter(RemoteConfiguration.OrderingGuarantee.class, this.orderingGuarantee);
-      newInjector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, this.numberOfTries);
-      newInjector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, this.retryTimeout);
-      newInjector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-      newInjector.bindVolatileInstance(TransportFactory.class, this.transportFactory);
-      newInjector.bindVolatileInstance(TcpPortProvider.class, this.tcpPortProvider);
-      return newInjector.getInstance(RemoteManager.class);
-    } catch (InjectionException e) {
-      throw new RuntimeException(e);
-    }
+  public RemoteManager getInstance(final String newRmName) {
+    return getInstance(newRmName, 0, this.codec, this.errorHandler);
   }
 
   @Override
-  @SuppressWarnings("checkstyle:hiddenfield")
-  public <T> RemoteManager getInstance(final String name,
-                                       final String hostAddress,
-                                       final int listeningPort,
-                                       final Codec<T> codec,
-                                       final EventHandler<Throwable> errorHandler,
-                                       final boolean orderingGuarantee,
-                                       final int numberOfTries,
-                                       final int retryTimeout,
-                                       final LocalAddressProvider localAddressProvider,
-                                       final TcpPortProvider tcpPortProvider) {
-    try {
-      final Injector newInjector = injector.forkInjector();
-      newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
-      newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
-      newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
-      newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);
-      newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, errorHandler);
-      newInjector.bindVolatileParameter(RemoteConfiguration.OrderingGuarantee.class, orderingGuarantee);
-      newInjector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, numberOfTries);
-      newInjector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, retryTimeout);
-      newInjector.bindVolatileInstance(LocalAddressProvider.class, localAddressProvider);
-      newInjector.bindVolatileInstance(TransportFactory.class, this.transportFactory);
-      newInjector.bindVolatileInstance(TcpPortProvider.class, tcpPortProvider);
-      return newInjector.getInstance(RemoteManager.class);
-    } catch (InjectionException e) {
-      throw new RuntimeException(e);
-    }
+  public <T> RemoteManager getInstance(final String newRmName,
+                                       final String newHostAddress,
+                                       final int newListeningPort,
+                                       final Codec<T> newCodec) {
+    return getInstance(newRmName, newHostAddress, newListeningPort, newCodec,
+        this.errorHandler, this.orderingGuarantee, this.numberOfTries, this.retryTimeout,
+        this.localAddressProvider, this.tcpPortProvider);
   }
 
   @Override
-  @SuppressWarnings("checkstyle:hiddenfield")
-  public <T> RemoteManager getInstance(final String name,
-                                       final String hostAddress,
-                                       final int listeningPort,
-                                       final Codec<T> codec,
-                                       final EventHandler<Throwable> errorHandler,
-                                       final boolean orderingGuarantee,
-                                       final int numberOfTries,
-                                       final int retryTimeout) {
-    try {
-      final Injector newInjector = injector.forkInjector();
-      newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
-      newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, hostAddress);
-      newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
-      newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);
-      newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, errorHandler);
-      newInjector.bindVolatileParameter(RemoteConfiguration.OrderingGuarantee.class, orderingGuarantee);
-      newInjector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, numberOfTries);
-      newInjector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, retryTimeout);
-      newInjector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-      newInjector.bindVolatileInstance(TransportFactory.class, this.transportFactory);
-      newInjector.bindVolatileInstance(TcpPortProvider.class, this.tcpPortProvider);
-      return newInjector.getInstance(RemoteManager.class);
-    } catch (InjectionException e) {
-      throw new RuntimeException(e);
-    }
+  public <T> RemoteManager getInstance(final String newRmName,
+                                       final String newHostAddress,
+                                       final int newListeningPort,
+                                       final Codec<T> newCodec,
+                                       final EventHandler<Throwable> newErrorHandler,
+                                       final boolean newOrderingGuarantee,
+                                       final int newNumberOfTries,
+                                       final int newRetryTimeout) {
+    return getInstance(newRmName, newHostAddress, newListeningPort, newCodec, newErrorHandler,
+        newOrderingGuarantee, newNumberOfTries, newRetryTimeout, this.localAddressProvider, this.tcpPortProvider);
   }
 
   @Override
-  @SuppressWarnings("checkstyle:hiddenfield")
-  public <T> RemoteManager getInstance(
-      final String name, final Codec<T> codec, final EventHandler<Throwable> errorHandler) {
-    try {
-      final Injector newInjector = injector.forkInjector();
-      newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
-      newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);
-      newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, errorHandler);
-      newInjector.bindVolatileParameter(RemoteConfiguration.OrderingGuarantee.class, this.orderingGuarantee);
-      newInjector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, this.numberOfTries);
-      newInjector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, this.retryTimeout);
-      newInjector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-      newInjector.bindVolatileInstance(TransportFactory.class, this.transportFactory);
-      newInjector.bindVolatileInstance(TcpPortProvider.class, this.tcpPortProvider);
-      return newInjector.getInstance(RemoteManager.class);
-    } catch (InjectionException e) {
-      throw new RuntimeException(e);
-    }
+  public <T> RemoteManager getInstance(final String newRmName,
+                                       final Codec<T> newCodec,
+                                       final EventHandler<Throwable> newErrorHandler) {
+    return getInstance(newRmName, 0, newCodec, newErrorHandler);
   }
 
   @Override
-  @SuppressWarnings("checkstyle:hiddenfield")
-  public <T> RemoteManager getInstance(final String name,
-                                       final int listeningPort,
-                                       final Codec<T> codec,
-                                       final EventHandler<Throwable> errorHandler) {
+  public <T> RemoteManager getInstance(final String newRmName,
+                                       final int newListeningPort,
+                                       final Codec<T> newCodec,
+                                       final EventHandler<Throwable> newErrorHandler) {
+    return getInstance(newRmName, null, newListeningPort, newCodec, newErrorHandler, this.orderingGuarantee,
+        this.numberOfTries, this.retryTimeout, this.localAddressProvider, this.tcpPortProvider);
+  }
+
+  @Override
+  public <T> RemoteManager getInstance(final String newRmName,
+                                       final String newHostAddress,
+                                       final int newListeningPort,
+                                       final Codec<T> newCodec,
+                                       final EventHandler<Throwable> newErrorHandler,
+                                       final boolean newOrderingGuarantee,
+                                       final int newNumberOfTries,
+                                       final int newRetryTimeout,
+                                       final LocalAddressProvider newLocalAddressProvider,
+                                       final TcpPortProvider newTcpPortProvider) {
     try {
+
       final Injector newInjector = injector.forkInjector();
-      newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, name);
-      newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, listeningPort);
-      newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, codec);
-      newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, errorHandler);
-      newInjector.bindVolatileParameter(RemoteConfiguration.OrderingGuarantee.class, this.orderingGuarantee);
-      newInjector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, this.numberOfTries);
-      newInjector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, this.retryTimeout);
-      newInjector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
+
+      if (newHostAddress != null) {
+        newInjector.bindVolatileParameter(RemoteConfiguration.HostAddress.class, newHostAddress);
+      }
+
+      if (newListeningPort > 0) {
+        newInjector.bindVolatileParameter(RemoteConfiguration.Port.class, newListeningPort);
+      }
+
+      newInjector.bindVolatileParameter(RemoteConfiguration.ManagerName.class, newRmName);
+      newInjector.bindVolatileParameter(RemoteConfiguration.MessageCodec.class, newCodec);
+      newInjector.bindVolatileParameter(RemoteConfiguration.ErrorHandler.class, newErrorHandler);
+      newInjector.bindVolatileParameter(RemoteConfiguration.OrderingGuarantee.class, newOrderingGuarantee);
+      newInjector.bindVolatileParameter(RemoteConfiguration.NumberOfTries.class, newNumberOfTries);
+      newInjector.bindVolatileParameter(RemoteConfiguration.RetryTimeout.class, newRetryTimeout);
+      newInjector.bindVolatileInstance(LocalAddressProvider.class, newLocalAddressProvider);
       newInjector.bindVolatileInstance(TransportFactory.class, this.transportFactory);
-      newInjector.bindVolatileInstance(TcpPortProvider.class, this.tcpPortProvider);
+      newInjector.bindVolatileInstance(TcpPortProvider.class, newTcpPortProvider);
+
       return newInjector.getInstance(RemoteManager.class);
-    } catch (InjectionException e) {
+
+    } catch (final InjectionException e) {
       throw new RuntimeException(e);
     }
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManagerFactory.java
@@ -62,6 +62,19 @@ public interface RemoteManagerFactory {
                                 final EventHandler<Throwable> errorHandler);
 
   /**
+   * @param name                 the name of the returned RemoteManager to instantiate.
+   * @param hostAddress          the address the returned RemoteManager binds to.
+   * @param listeningPort        the port on which the returned RemoteManager listens.
+   * @param codec                the codec to use to decode the messages sent to / by this RemoteManager.
+   * @param <T>                  the message type sent / received by the returned RemoteManager.
+   * @return a new instance of RemoteManager with all parameters but the given one injected via Tang.
+   */
+  <T> RemoteManager getInstance(final String name,
+                                final String hostAddress,
+                                final int listeningPort,
+                                final Codec<T> codec);
+
+  /**
    * The old constructor of DefaultRemoteManagerImplementation. Avoid if you can.
    *
    * @param name              the name of the returned RemoteManager to instantiate.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
@@ -31,7 +31,9 @@ import java.util.logging.Logger;
  * A LocalAddressProvider that uses <code>Inet4Address.getLocalHost().getHostAddress()</code>.
  */
 public final class HostnameBasedLocalAddressProvider implements LocalAddressProvider {
+
   private static final Logger LOG = Logger.getLogger(HostnameBasedLocalAddressProvider.class.getName());
+
   private String cached = null;
 
   /**
@@ -62,5 +64,10 @@ public final class HostnameBasedLocalAddressProvider implements LocalAddressProv
     return Tang.Factory.getTang().newConfigurationBuilder()
         .bind(LocalAddressProvider.class, HostnameBasedLocalAddressProvider.class)
         .build();
+  }
+
+  @Override
+  public String toString() {
+    return "HostnameBasedLocalAddressProvider:" + this.getLocalAddress();
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LoopbackLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LoopbackLocalAddressProvider.java
@@ -31,6 +31,8 @@ import java.net.InetAddress;
  */
 public final class LoopbackLocalAddressProvider implements LocalAddressProvider {
 
+  private final String address = InetAddress.getLoopbackAddress().getHostAddress();
+
   @Inject
   private LoopbackLocalAddressProvider() {
   }
@@ -38,7 +40,7 @@ public final class LoopbackLocalAddressProvider implements LocalAddressProvider 
   @Override
   public String getLocalAddress() {
     // Use the loopback address.
-    return InetAddress.getLoopbackAddress().getHostAddress();
+    return this.address;
   }
 
   @Override
@@ -47,5 +49,10 @@ public final class LoopbackLocalAddressProvider implements LocalAddressProvider 
         .bind(LocalAddressProvider.class, LoopbackLocalAddressProvider.class)
         .bindNamedParameter(RemoteConfiguration.HostAddress.class, getLocalAddress())
         .build();
+  }
+
+  @Override
+  public String toString() {
+    return "LoopbackLocalAddressProvider:" + address;
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -117,7 +117,7 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
 
     if (LOG.isLoggable(Level.FINE)) {
       LOG.log(Level.FINE, "RemoteManager: {0} destinationIdentifier: {1} messageType: {2}",
-          new Object[] {this.name, destinationIdentifier, messageType.getName()});
+          new Object[] {this.name, destinationIdentifier, messageType.getCanonicalName()});
     }
 
     return new ProxyEventHandler<>(this.myIdentifier, destinationIdentifier,
@@ -130,12 +130,11 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
    */
   @Override
   public <T, U extends T> AutoCloseable registerHandler(
-      final RemoteIdentifier sourceIdentifier,
-      final Class<U> messageType, final EventHandler<T> theHandler) {
+      final RemoteIdentifier sourceIdentifier, final Class<U> messageType, final EventHandler<T> theHandler) {
 
     if (LOG.isLoggable(Level.FINE)) {
-      LOG.log(Level.FINE, "RemoteManager: {0} remoteid: {1} messageType: {2} handler: {3}",
-          new Object[] {this.name, sourceIdentifier, messageType.getName(), theHandler.getClass().getName()});
+      LOG.log(Level.FINE, "RemoteManager: {0} remoteId: {1} messageType: {2} handler: {3}", new Object[] {
+          this.name, sourceIdentifier, messageType.getCanonicalName(), theHandler.getClass().getCanonicalName()});
     }
 
     return this.handlerContainer.registerHandler(sourceIdentifier, messageType, theHandler);
@@ -149,8 +148,8 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
       final Class<U> messageType, final EventHandler<RemoteMessage<T>> theHandler) {
 
     if (LOG.isLoggable(Level.FINE)) {
-      LOG.log(Level.FINE, "RemoteManager: {0} messageType: {1} handler: {2}",
-          new Object[] {this.name, messageType.getName(), theHandler.getClass().getName()});
+      LOG.log(Level.FINE, "RemoteManager: {0} messageType: {1} handler: {2}", new Object[] {
+          this.name, messageType.getCanonicalName(), theHandler.getClass().getCanonicalName()});
     }
 
     return this.handlerContainer.registerHandler(messageType, theHandler);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -234,6 +234,6 @@ public final class DefaultRemoteManagerImplementation implements RemoteManager {
 
   @Override
   public String toString() {
-    return String.format("RemoteManager: { id:%s handler:%s }", this.myIdentifier, this.handlerContainer);
+    return String.format("RemoteManager: { id: %s handler: %s }", this.myIdentifier, this.handlerContainer);
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -89,7 +89,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
 
     LOG.log(Level.FINER,
         "Add handler for tuple: {0},{1}",
-        new Object[] {tuple.getT1(), tuple.getT2().getName()});
+        new Object[] {tuple.getT1(), tuple.getT2().getCanonicalName()});
 
     return new SubscriptionHandler<>(tuple, this.unsubscribeTuple);
   }
@@ -106,7 +106,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
 
     this.msgTypeToHandlerMap.put(messageType, theHandler);
 
-    LOG.log(Level.FINER, "Add handler for class: {0}", messageType.getName());
+    LOG.log(Level.FINER, "Add handler for class: {0}", messageType.getCanonicalName());
 
     return new SubscriptionHandler<>(messageType, this.unsubscribeClass);
   }
@@ -141,7 +141,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
       this.msgTypeToHandlerMap.remove(token);
     } else {
       throw new RemoteRuntimeException(
-          "Unknown subscription type: " + subscription.getClass().getName());
+          "Unknown subscription type: " + subscription.getClass().getCanonicalName());
     }
   }
 


### PR DESCRIPTION
minor fixes to pending PR REEF-1763 after the code review:
   * use dependency injection all the way down in ProtocolSerializer
   * minor stylistic changes + javadocs
   * minor fixes to the MultiObserverImpl API to make stuff compile again + minor cleanup
   * use default injection parameters in for remote manager in ProtocolSerializerTest
   * fix the timestamp in JavaBridge
   * other minor fixes

**TODO:** Use proper configuration to set the `ProtocolSerializerNamespace` parameter to `"org.apache.reef.bridge.message"`